### PR TITLE
feat: Added ability to set the name of a terminal command prior to it being registered with any global commands.

### DIFF
--- a/src/Evands.Pellucid.Pro/Terminal/Commands/TerminalCommandBase.cs
+++ b/src/Evands.Pellucid.Pro/Terminal/Commands/TerminalCommandBase.cs
@@ -18,6 +18,7 @@
 // </copyright>
 #endregion
 
+using System;
 namespace Evands.Pellucid.Terminal.Commands
 {
     /// <summary>
@@ -60,7 +61,10 @@ namespace Evands.Pellucid.Terminal.Commands
         }
 
         /// <summary>
-        /// Gets the name of the command.
+        /// Gets or sets the name of the command.
+        /// <para>
+        /// When setting the name this must be set prior to registering the command.
+        /// </para>
         /// </summary>
         public string Name
         {
@@ -72,6 +76,18 @@ namespace Evands.Pellucid.Terminal.Commands
                 }
 
                 return name;
+            }
+
+            set
+            {
+                if (GetCommandsRegisteredWith().Length == 0)
+                {
+                    name = value;
+                }
+                else
+                {
+                    throw new InvalidOperationException("You cannot set the name of a terminal command after it has been registered with a global command.");
+                }
             }
         }
 

--- a/src/Evands.Pellucid.Tests/Terminal/Commands/TerminalCommandBaseTests.cs
+++ b/src/Evands.Pellucid.Tests/Terminal/Commands/TerminalCommandBaseTests.cs
@@ -98,5 +98,60 @@ namespace Evands.Pellucid.Terminal.Commands.Attributes
             gc.RemoveFromConsole();
             gc.Dispose();
         }
+
+        [TestMethod]
+        public void SetName_Throws_InvalidOperationException_When_Registered()
+        {
+            Crestron.SimplSharp.CrestronConsole.AddNewConsoleCommandResult = true;
+            var t = new TestCommand2();
+            var gc = new GlobalCommand("SomethingTest", "t", Access.Administrator);
+            var added = gc.AddToConsole();
+            Assert.IsTrue(added);
+            var reg = t.RegisterCommand("SomethingTest");
+            Assert.IsTrue(reg == RegisterResult.Success);
+            var threw = false;
+            try
+            {
+                t.Name = "Throws Exception";
+            }
+            catch (InvalidOperationException)
+            {
+                threw = true;
+            }
+
+            gc.RemoveFromConsole();
+            gc.Dispose();
+
+            Assert.IsTrue(threw);
+        }
+
+        [TestMethod]
+        public void SetName_SetsName_When_NotRegistered()
+        {
+            var t = new TestCommand2();
+            Assert.IsTrue(t.Name == "TestCommand2");
+            var expected = "NewName";
+            t.Name = expected;
+            Assert.IsTrue(t.Name == expected);
+        }
+
+        [TestMethod]
+        public void CommandExecute_When_NameSetManually()
+        {
+            Crestron.SimplSharp.CrestronConsole.AddNewConsoleCommandResult = true;
+            var t = new TestCommand2();
+            t.Name = "NewName";
+            var gc = new GlobalCommand("SomethingTest", "t", Access.Administrator);
+            var added = gc.AddToConsole();
+            Assert.IsTrue(added);
+            var reg = t.RegisterCommand("SomethingTest");
+            Assert.IsTrue(reg == RegisterResult.Success);
+            Crestron.SimplSharp.CrestronConsole.Messages.Capacity = 0;
+            gc.ExecuteCommand("NewName Test");
+            Assert.IsTrue(Crestron.SimplSharp.CrestronConsole.Messages.ToString().Contains("Default test command executed."));
+
+            gc.RemoveFromConsole();
+            gc.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Resolves #54